### PR TITLE
feat: add presigned URL upload support for S3 artifacts

### DIFF
--- a/sagemaker_mlflow/s3_presigned_artifact_repo.py
+++ b/sagemaker_mlflow/s3_presigned_artifact_repo.py
@@ -14,6 +14,7 @@
 import logging
 import os
 import posixpath
+from typing import Optional
 from urllib.parse import urlparse
 
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
@@ -39,12 +40,12 @@ _PRESIGNED_UPLOAD_ENDPOINT = "/api/2.0/mlflow/artifacts/presigned-upload-url"
 _PERMANENT_FAILURE_CODES = (404, 501)
 
 
-class SageMakerS3ArtifactRepository(S3ArtifactRepository):
-    """S3 artifact repository with presigned URL upload support for SageMaker.
+class S3PresignedArtifactRepository(S3ArtifactRepository):
+    """S3 artifact repository with optional presigned URL upload support.
 
     Extends S3ArtifactRepository to optionally upload artifacts via presigned URLs
-    obtained from the SageMaker MLflow tracking server. This avoids the need for
-    the client to have direct S3 write credentials.
+    obtained from the MLflow tracking server. This avoids the need for the client
+    to have direct S3 write credentials.
 
     When the SAGEMAKER_PRESIGNED_URL_UPLOAD environment variable is set to "true",
     artifact uploads will first attempt to use presigned URLs. If the server does
@@ -60,12 +61,12 @@ class SageMakerS3ArtifactRepository(S3ArtifactRepository):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._use_presigned = (
+        self._use_presigned: bool = (
             os.environ.get(_SAGEMAKER_PRESIGNED_URL_UPLOAD_ENV_VAR, "").lower() == "true"
         )
-        self._presigned_supported = None
+        self._presigned_supported: Optional[bool] = None
 
-    def _should_use_presigned(self):
+    def _should_use_presigned(self) -> bool:
         """Check whether presigned upload should be attempted for this call."""
         return (
             self._use_presigned
@@ -74,16 +75,20 @@ class SageMakerS3ArtifactRepository(S3ArtifactRepository):
             and self._extract_run_id() is not None
         )
 
-    def log_artifact(self, local_file, artifact_path=None):
+    def log_artifact(self, local_file: str, artifact_path: Optional[str] = None) -> None:
         if self._should_use_presigned():
             try:
                 self._upload_via_presigned_url(local_file, artifact_path)
                 return
             except Exception:
-                pass
+                logger.debug("Presigned upload attempt failed; falling back to direct S3", exc_info=True)
         super().log_artifact(local_file, artifact_path)
 
-    def log_artifacts(self, local_dir, artifact_path=None):
+    def log_artifacts(self, local_dir: str, artifact_path: Optional[str] = None) -> None:
+        if not self._should_use_presigned():
+            super().log_artifacts(local_dir, artifact_path)
+            return
+
         local_dir = os.path.abspath(local_dir)
         for root, _, filenames in os.walk(local_dir):
             if root == local_dir:
@@ -102,7 +107,7 @@ class SageMakerS3ArtifactRepository(S3ArtifactRepository):
                     file_artifact_path = None
                 self.log_artifact(local_file, file_artifact_path)
 
-    def _extract_run_id(self):
+    def _extract_run_id(self) -> Optional[str]:
         """Extract run_id from artifact_uri using reverse scan for last 'artifacts' segment.
 
         Pattern: s3://bucket/.../<run_id>/artifacts/...
@@ -119,7 +124,7 @@ class SageMakerS3ArtifactRepository(S3ArtifactRepository):
             pass
         return None
 
-    def _get_tracking_host_creds(self):
+    def _get_tracking_host_creds(self) -> rest_utils.MlflowHostCreds:
         """Build MlflowHostCreds for the SageMaker tracking server.
 
         Follows the pattern in mlflow_sagemaker_store.py: uses
@@ -140,7 +145,7 @@ class SageMakerS3ArtifactRepository(S3ArtifactRepository):
             server_cert_path=os.environ.get(_TRACKING_SERVER_CERT_PATH_ENV_VAR),
         )
 
-    def _build_upload_path(self, local_file, artifact_path):
+    def _build_upload_path(self, local_file: str, artifact_path: Optional[str]) -> str:
         """Construct the relative path sent to the server as the 'path' parameter.
 
         Must match how S3ArtifactRepository.log_artifact builds the S3 key:
@@ -151,18 +156,16 @@ class SageMakerS3ArtifactRepository(S3ArtifactRepository):
             return posixpath.join(artifact_path, filename)
         return filename
 
-    def _request_presigned_url(self, run_id, path, expiration=900):
+    def _request_presigned_url(self, run_id: str, path: str, expiration: int = 900):
         """Request a presigned upload URL from the tracking server (SigV4-authenticated).
 
         Uses raise_on_status=False and max_retries=0 so we always get a response
-        object back immediately for
-        HTTP error codes (404, 501, 503, etc.) rather than having urllib3 raise
-        or retry. Retries are handled at the application level (next log_artifact
-        call re-attempts presigned). This lets _upload_via_presigned_url inspect
-        the status code and apply the correct caching policy.
+        object back immediately for HTTP error codes (404, 501, 503, etc.) rather
+        than having urllib3 raise or retry. This lets _upload_via_presigned_url
+        inspect the status code and apply the correct caching policy.
         """
         host_creds = self._get_tracking_host_creds()
-        response = rest_utils.http_request(
+        return rest_utils.http_request(
             host_creds,
             _PRESIGNED_UPLOAD_ENDPOINT,
             "POST",
@@ -170,9 +173,8 @@ class SageMakerS3ArtifactRepository(S3ArtifactRepository):
             raise_on_status=False,
             max_retries=0,
         )
-        return response
 
-    def _upload_via_presigned_url(self, local_file, artifact_path):
+    def _upload_via_presigned_url(self, local_file: str, artifact_path: Optional[str]) -> None:
         """Attempt to upload a file via a presigned URL.
 
         Two distinct HTTP paths:
@@ -181,6 +183,8 @@ class SageMakerS3ArtifactRepository(S3ArtifactRepository):
         2. S3 presigned URL PUT: NO auth — authorization is embedded in the
            presigned URL signature. Uses cloud_storage_http_request (same pattern
            as presigned_url_artifact_repo.py and optimized_s3_artifact_repo.py).
+
+        Streams the file directly to avoid loading large artifacts into memory.
         """
         path = self._build_upload_path(local_file, artifact_path)
         run_id = self._extract_run_id()
@@ -224,21 +228,19 @@ class SageMakerS3ArtifactRepository(S3ArtifactRepository):
         headers = response_json.get("headers", {})
 
         with open(local_file, "rb") as f:
-            file_data = f.read()
-
-        try:
-            put_response = cloud_storage_http_request(
-                "put",
-                presigned_url,
-                data=file_data,
-                headers=headers,
-            )
-            put_response.raise_for_status()
-        except Exception as e:
-            logger.warning(
-                "Presigned upload failed (transient): %s; falling back to direct S3", e
-            )
-            raise
+            try:
+                put_response = cloud_storage_http_request(
+                    "put",
+                    presigned_url,
+                    data=f,
+                    headers=headers,
+                )
+                put_response.raise_for_status()
+            except Exception as e:
+                logger.warning(
+                    "Presigned upload failed (transient): %s; falling back to direct S3", e
+                )
+                raise
 
         self._presigned_supported = True
         logger.debug("Artifact uploaded via presigned URL: %s", path)

--- a/sagemaker_mlflow/s3_presigned_artifact_repo.py
+++ b/sagemaker_mlflow/s3_presigned_artifact_repo.py
@@ -1,0 +1,244 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import logging
+import os
+import posixpath
+from urllib.parse import urlparse
+
+from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
+from mlflow.utils import rest_utils
+from mlflow.utils.request_utils import cloud_storage_http_request
+
+from sagemaker_mlflow.mlflow_sagemaker_helpers import SageMakerMLflowHostMetadataProvider
+
+logger = logging.getLogger(__name__)
+
+_SAGEMAKER_PRESIGNED_URL_UPLOAD_ENV_VAR = "SAGEMAKER_PRESIGNED_URL_UPLOAD"
+
+_TRACKING_INSECURE_TLS_ENV_VAR = "MLFLOW_TRACKING_INSECURE_TLS"
+_TRACKING_USERNAME_ENV_VAR = "MLFLOW_TRACKING_USERNAME"
+_TRACKING_PASSWORD_ENV_VAR = "MLFLOW_TRACKING_PASSWORD"
+_TRACKING_TOKEN_ENV_VAR = "MLFLOW_TRACKING_TOKEN"
+
+_TRACKING_CLIENT_CERT_PATH_ENV_VAR = "MLFLOW_TRACKING_CLIENT_CERT_PATH"
+_TRACKING_SERVER_CERT_PATH_ENV_VAR = "MLFLOW_TRACKING_SERVER_CERT_PATH"
+
+_PRESIGNED_UPLOAD_ENDPOINT = "/api/2.0/mlflow/artifacts/presigned-upload-url"
+
+_PERMANENT_FAILURE_CODES = (404, 501)
+
+
+class SageMakerS3ArtifactRepository(S3ArtifactRepository):
+    """S3 artifact repository with presigned URL upload support for SageMaker.
+
+    Extends S3ArtifactRepository to optionally upload artifacts via presigned URLs
+    obtained from the SageMaker MLflow tracking server. This avoids the need for
+    the client to have direct S3 write credentials.
+
+    When the SAGEMAKER_PRESIGNED_URL_UPLOAD environment variable is set to "true",
+    artifact uploads will first attempt to use presigned URLs. If the server does
+    not support the presigned upload endpoint, the class falls back to direct S3
+    uploads transparently.
+
+    Failure handling:
+        - 404/501 from the tracking server: permanently cached as unsupported,
+          all subsequent uploads use direct S3.
+        - 503 or PUT failures: treated as transient, presigned upload retried
+          on the next call.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._use_presigned = (
+            os.environ.get(_SAGEMAKER_PRESIGNED_URL_UPLOAD_ENV_VAR, "").lower() == "true"
+        )
+        self._presigned_supported = None
+
+    def _should_use_presigned(self):
+        """Check whether presigned upload should be attempted for this call."""
+        return (
+            self._use_presigned
+            and self._presigned_supported is not False
+            and self.tracking_uri is not None
+            and self._extract_run_id() is not None
+        )
+
+    def log_artifact(self, local_file, artifact_path=None):
+        if self._should_use_presigned():
+            try:
+                self._upload_via_presigned_url(local_file, artifact_path)
+                return
+            except Exception:
+                pass
+        super().log_artifact(local_file, artifact_path)
+
+    def log_artifacts(self, local_dir, artifact_path=None):
+        local_dir = os.path.abspath(local_dir)
+        for root, _, filenames in os.walk(local_dir):
+            if root == local_dir:
+                rel_dir = ""
+            else:
+                rel_dir = os.path.relpath(root, local_dir)
+            for filename in filenames:
+                local_file = os.path.join(root, filename)
+                if artifact_path and rel_dir:
+                    file_artifact_path = posixpath.join(artifact_path, rel_dir.replace(os.sep, "/"))
+                elif artifact_path:
+                    file_artifact_path = artifact_path
+                elif rel_dir:
+                    file_artifact_path = rel_dir.replace(os.sep, "/")
+                else:
+                    file_artifact_path = None
+                self.log_artifact(local_file, file_artifact_path)
+
+    def _extract_run_id(self):
+        """Extract run_id from artifact_uri using reverse scan for last 'artifacts' segment.
+
+        Pattern: s3://bucket/.../<run_id>/artifacts/...
+        Uses reverse scan because 'artifacts' may appear in the URI prefix path
+        (e.g., s3://bucket/ml-artifacts/<exp_id>/<run_id>/artifacts).
+        """
+        try:
+            parsed = urlparse(self.artifact_uri)
+            parts = parsed.path.strip("/").split("/")
+            for i in range(len(parts) - 1, 0, -1):
+                if parts[i] == "artifacts":
+                    return parts[i - 1]
+        except Exception:
+            pass
+        return None
+
+    def _get_tracking_host_creds(self):
+        """Build MlflowHostCreds for the SageMaker tracking server.
+
+        Follows the pattern in mlflow_sagemaker_store.py: uses
+        SageMakerMLflowHostMetadataProvider to convert the tracking ARN into
+        a URL, then returns MlflowHostCreds with auth="arn" to trigger SigV4
+        signing via the AuthProvider entry point.
+        """
+        provider = SageMakerMLflowHostMetadataProvider()
+        provider.set_arn(self.tracking_uri)
+        return rest_utils.MlflowHostCreds(
+            host=provider.construct_tracking_server_url(),
+            username=os.environ.get(_TRACKING_USERNAME_ENV_VAR),
+            password=os.environ.get(_TRACKING_PASSWORD_ENV_VAR),
+            token=os.environ.get(_TRACKING_TOKEN_ENV_VAR),
+            auth="arn",
+            ignore_tls_verification=os.environ.get(_TRACKING_INSECURE_TLS_ENV_VAR) == "true",
+            client_cert_path=os.environ.get(_TRACKING_CLIENT_CERT_PATH_ENV_VAR),
+            server_cert_path=os.environ.get(_TRACKING_SERVER_CERT_PATH_ENV_VAR),
+        )
+
+    def _build_upload_path(self, local_file, artifact_path):
+        """Construct the relative path sent to the server as the 'path' parameter.
+
+        Must match how S3ArtifactRepository.log_artifact builds the S3 key:
+        artifact_path (if any) + basename of local_file.
+        """
+        filename = os.path.basename(local_file)
+        if artifact_path:
+            return posixpath.join(artifact_path, filename)
+        return filename
+
+    def _request_presigned_url(self, run_id, path, expiration=900):
+        """Request a presigned upload URL from the tracking server (SigV4-authenticated).
+
+        Uses raise_on_status=False and max_retries=0 so we always get a response
+        object back immediately for
+        HTTP error codes (404, 501, 503, etc.) rather than having urllib3 raise
+        or retry. Retries are handled at the application level (next log_artifact
+        call re-attempts presigned). This lets _upload_via_presigned_url inspect
+        the status code and apply the correct caching policy.
+        """
+        host_creds = self._get_tracking_host_creds()
+        response = rest_utils.http_request(
+            host_creds,
+            _PRESIGNED_UPLOAD_ENDPOINT,
+            "POST",
+            json={"run_id": run_id, "path": path, "expiration": expiration},
+            raise_on_status=False,
+            max_retries=0,
+        )
+        return response
+
+    def _upload_via_presigned_url(self, local_file, artifact_path):
+        """Attempt to upload a file via a presigned URL.
+
+        Two distinct HTTP paths:
+        1. Tracking server API call (_request_presigned_url): SigV4-authenticated
+           via rest_utils.http_request.
+        2. S3 presigned URL PUT: NO auth — authorization is embedded in the
+           presigned URL signature. Uses cloud_storage_http_request (same pattern
+           as presigned_url_artifact_repo.py and optimized_s3_artifact_repo.py).
+        """
+        path = self._build_upload_path(local_file, artifact_path)
+        run_id = self._extract_run_id()
+
+        try:
+            response = self._request_presigned_url(run_id, path)
+        except Exception as e:
+            logger.warning(
+                "Presigned upload request failed: %s; falling back to direct S3", e
+            )
+            raise
+
+        if response.status_code in _PERMANENT_FAILURE_CODES:
+            self._presigned_supported = False
+            logger.info(
+                "Presigned upload not supported by server (HTTP %s); "
+                "falling back to direct S3",
+                response.status_code,
+            )
+            raise Exception(
+                f"Presigned upload not supported (HTTP {response.status_code})"
+            )
+
+        if response.status_code == 503:
+            logger.warning(
+                "Presigned upload failed (transient, HTTP 503); falling back to direct S3"
+            )
+            raise Exception("Presigned upload failed (HTTP 503)")
+
+        if not response.ok:
+            logger.warning(
+                "Presigned upload request failed (HTTP %s); falling back to direct S3",
+                response.status_code,
+            )
+            raise Exception(
+                f"Presigned upload request failed (HTTP {response.status_code})"
+            )
+
+        response_json = response.json()
+        presigned_url = response_json.get("presigned_url")
+        headers = response_json.get("headers", {})
+
+        with open(local_file, "rb") as f:
+            file_data = f.read()
+
+        try:
+            put_response = cloud_storage_http_request(
+                "put",
+                presigned_url,
+                data=file_data,
+                headers=headers,
+            )
+            put_response.raise_for_status()
+        except Exception as e:
+            logger.warning(
+                "Presigned upload failed (transient): %s; falling back to direct S3", e
+            )
+            raise
+
+        self._presigned_supported = True
+        logger.debug("Artifact uploaded via presigned URL: %s", path)

--- a/sagemaker_mlflow/s3_presigned_artifact_repo.py
+++ b/sagemaker_mlflow/s3_presigned_artifact_repo.py
@@ -25,7 +25,7 @@ from sagemaker_mlflow.mlflow_sagemaker_helpers import SageMakerMLflowHostMetadat
 
 logger = logging.getLogger(__name__)
 
-_SAGEMAKER_PRESIGNED_URL_UPLOAD_ENV_VAR = "SAGEMAKER_PRESIGNED_URL_UPLOAD"
+_SAGEMAKER_PRESIGNED_URL_UPLOAD_ENV_VAR = "SAGEMAKER_PRESIGNED_URL_UPLOAD_ENABLED"
 
 _TRACKING_INSECURE_TLS_ENV_VAR = "MLFLOW_TRACKING_INSECURE_TLS"
 _TRACKING_USERNAME_ENV_VAR = "MLFLOW_TRACKING_USERNAME"
@@ -37,8 +37,6 @@ _TRACKING_SERVER_CERT_PATH_ENV_VAR = "MLFLOW_TRACKING_SERVER_CERT_PATH"
 
 _PRESIGNED_UPLOAD_ENDPOINT = "/api/2.0/mlflow/artifacts/presigned-upload-url"
 
-_PERMANENT_FAILURE_CODES = (404, 501)
-
 
 class S3PresignedArtifactRepository(S3ArtifactRepository):
     """S3 artifact repository with optional presigned URL upload support.
@@ -47,16 +45,14 @@ class S3PresignedArtifactRepository(S3ArtifactRepository):
     obtained from the MLflow tracking server. This avoids the need for the client
     to have direct S3 write credentials.
 
-    When the SAGEMAKER_PRESIGNED_URL_UPLOAD environment variable is set to "true",
-    artifact uploads will first attempt to use presigned URLs. If the server does
-    not support the presigned upload endpoint, the class falls back to direct S3
-    uploads transparently.
+    When the SAGEMAKER_PRESIGNED_URL_UPLOAD_ENABLED environment variable is set to
+    "true", all artifact uploads use presigned URLs. If the presigned upload fails
+    for any reason (server doesn't support the endpoint, network error, S3 PUT
+    failure), the exception propagates to the caller — there is no silent fallback
+    to direct S3.
 
-    Failure handling:
-        - 404/501 from the tracking server: permanently cached as unsupported,
-          all subsequent uploads use direct S3.
-        - 503 or PUT failures: treated as transient, presigned upload retried
-          on the next call.
+    When the environment variable is not set (the default), all behavior is
+    identical to the parent S3ArtifactRepository.
     """
 
     def __init__(self, *args, **kwargs):
@@ -64,25 +60,21 @@ class S3PresignedArtifactRepository(S3ArtifactRepository):
         self._use_presigned: bool = (
             os.environ.get(_SAGEMAKER_PRESIGNED_URL_UPLOAD_ENV_VAR, "").lower() == "true"
         )
-        self._presigned_supported: Optional[bool] = None
+        self._run_id_warning_logged: bool = False
 
     def _should_use_presigned(self) -> bool:
         """Check whether presigned upload should be attempted for this call."""
         return (
             self._use_presigned
-            and self._presigned_supported is not False
             and self.tracking_uri is not None
             and self._extract_run_id() is not None
         )
 
     def log_artifact(self, local_file: str, artifact_path: Optional[str] = None) -> None:
         if self._should_use_presigned():
-            try:
-                self._upload_via_presigned_url(local_file, artifact_path)
-                return
-            except Exception:
-                logger.debug("Presigned upload attempt failed; falling back to direct S3", exc_info=True)
-        super().log_artifact(local_file, artifact_path)
+            self._upload_via_presigned_url(local_file, artifact_path)
+        else:
+            super().log_artifact(local_file, artifact_path)
 
     def log_artifacts(self, local_dir: str, artifact_path: Optional[str] = None) -> None:
         if not self._should_use_presigned():
@@ -121,7 +113,20 @@ class S3PresignedArtifactRepository(S3ArtifactRepository):
                 if parts[i] == "artifacts":
                     return parts[i - 1]
         except Exception:
-            pass
+            if self._use_presigned and not self._run_id_warning_logged:
+                self._run_id_warning_logged = True
+                logger.warning(
+                    "Failed to parse run_id from artifact URI: %s",
+                    self.artifact_uri, exc_info=True,
+                )
+            return None
+        if self._use_presigned and not self._run_id_warning_logged:
+            self._run_id_warning_logged = True
+            logger.warning(
+                "Could not extract run_id from artifact URI (no 'artifacts' segment): %s. "
+                "Presigned upload will not be used.",
+                self.artifact_uri,
+            )
         return None
 
     def _get_tracking_host_creds(self) -> rest_utils.MlflowHostCreds:
@@ -157,13 +162,7 @@ class S3PresignedArtifactRepository(S3ArtifactRepository):
         return filename
 
     def _request_presigned_url(self, run_id: str, path: str, expiration: int = 900):
-        """Request a presigned upload URL from the tracking server (SigV4-authenticated).
-
-        Uses raise_on_status=False and max_retries=0 so we always get a response
-        object back immediately for HTTP error codes (404, 501, 503, etc.) rather
-        than having urllib3 raise or retry. This lets _upload_via_presigned_url
-        inspect the status code and apply the correct caching policy.
-        """
+        """Request a presigned upload URL from the tracking server (SigV4-authenticated)."""
         host_creds = self._get_tracking_host_creds()
         return rest_utils.http_request(
             host_creds,
@@ -175,7 +174,7 @@ class S3PresignedArtifactRepository(S3ArtifactRepository):
         )
 
     def _upload_via_presigned_url(self, local_file: str, artifact_path: Optional[str]) -> None:
-        """Attempt to upload a file via a presigned URL.
+        """Upload a file via a presigned URL.
 
         Two distinct HTTP paths:
         1. Tracking server API call (_request_presigned_url): SigV4-authenticated
@@ -189,38 +188,11 @@ class S3PresignedArtifactRepository(S3ArtifactRepository):
         path = self._build_upload_path(local_file, artifact_path)
         run_id = self._extract_run_id()
 
-        try:
-            response = self._request_presigned_url(run_id, path)
-        except Exception as e:
-            logger.warning(
-                "Presigned upload request failed: %s; falling back to direct S3", e
-            )
-            raise
-
-        if response.status_code in _PERMANENT_FAILURE_CODES:
-            self._presigned_supported = False
-            logger.info(
-                "Presigned upload not supported by server (HTTP %s); "
-                "falling back to direct S3",
-                response.status_code,
-            )
-            raise Exception(
-                f"Presigned upload not supported (HTTP {response.status_code})"
-            )
-
-        if response.status_code == 503:
-            logger.warning(
-                "Presigned upload failed (transient, HTTP 503); falling back to direct S3"
-            )
-            raise Exception("Presigned upload failed (HTTP 503)")
+        response = self._request_presigned_url(run_id, path)
 
         if not response.ok:
-            logger.warning(
-                "Presigned upload request failed (HTTP %s); falling back to direct S3",
-                response.status_code,
-            )
             raise Exception(
-                f"Presigned upload request failed (HTTP {response.status_code})"
+                f"Presigned upload URL request failed (HTTP {response.status_code})"
             )
 
         response_json = response.json()
@@ -228,19 +200,12 @@ class S3PresignedArtifactRepository(S3ArtifactRepository):
         headers = response_json.get("headers", {})
 
         with open(local_file, "rb") as f:
-            try:
-                put_response = cloud_storage_http_request(
-                    "put",
-                    presigned_url,
-                    data=f,
-                    headers=headers,
-                )
-                put_response.raise_for_status()
-            except Exception as e:
-                logger.warning(
-                    "Presigned upload failed (transient): %s; falling back to direct S3", e
-                )
-                raise
+            put_response = cloud_storage_http_request(
+                "put",
+                presigned_url,
+                data=f,
+                headers=headers,
+            )
+            put_response.raise_for_status()
 
-        self._presigned_supported = True
         logger.debug("Artifact uploaded via presigned URL: %s", path)

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,9 @@ setup(
         "mlflow.model_registry_store": (
             "arn=sagemaker_mlflow.mlflow_sagemaker_registry_store:" "MlflowSageMakerRegistryStore"
         ),
+        "mlflow.artifact_repository": (
+            "s3=sagemaker_mlflow.s3_presigned_artifact_repo:SageMakerS3ArtifactRepository"
+        ),
     },
     version=read_version(),
     description="AWS Plugin for MLflow with SageMaker",

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
             "arn=sagemaker_mlflow.mlflow_sagemaker_registry_store:" "MlflowSageMakerRegistryStore"
         ),
         "mlflow.artifact_repository": (
-            "s3=sagemaker_mlflow.s3_presigned_artifact_repo:SageMakerS3ArtifactRepository"
+            "s3=sagemaker_mlflow.s3_presigned_artifact_repo:S3PresignedArtifactRepository"
         ),
     },
     version=read_version(),

--- a/test/integration/tests/test_presigned_url_upload.py
+++ b/test/integration/tests/test_presigned_url_upload.py
@@ -23,7 +23,6 @@ Tests are skipped when the server does not support the presigned upload
 endpoint (HTTP 404), so they are safe to run against older servers.
 """
 
-import logging
 import os
 import tempfile
 
@@ -31,42 +30,13 @@ import mlflow
 import pytest
 
 from utils.boto_utils import get_file_data_from_s3
+from utils.presigned_utils import presigned_upload_supported
 from utils.random_utils import generate_uuid
-
-logger = logging.getLogger(__name__)
 
 _PRESIGNED_ENV_VAR = "SAGEMAKER_PRESIGNED_URL_UPLOAD"
 
 
-def _presigned_upload_supported(tracking_server_arn):
-    """Probe whether the tracking server supports the presigned upload endpoint."""
-    from mlflow.utils import rest_utils
-    from sagemaker_mlflow.mlflow_sagemaker_helpers import SageMakerMLflowHostMetadataProvider
-
-    provider = SageMakerMLflowHostMetadataProvider()
-    provider.set_arn(tracking_server_arn)
-    host_creds = rest_utils.MlflowHostCreds(
-        host=provider.construct_tracking_server_url(),
-        auth="arn",
-    )
-    try:
-        response = rest_utils.http_request(
-            host_creds,
-            "/api/2.0/mlflow/artifacts/presigned-upload-url",
-            "POST",
-            json={"run_id": "probe", "path": "probe.txt"},
-            raise_on_status=False,
-            max_retries=0,
-        )
-        # 404 = endpoint doesn't exist, 501 = not implemented
-        # Anything else (400, 403, etc.) means the endpoint exists
-        return response.status_code not in (404, 501)
-    except Exception as e:
-        logger.warning("Failed to probe presigned upload endpoint: %s", e)
-        return False
-
-
-def _parse_s3_uri(uri):
+def _parse_s3_uri(uri: str) -> tuple:
     """Parse s3://bucket/key into (bucket, key)."""
     if not uri.startswith("s3://"):
         raise ValueError(f"Invalid S3 URI: {uri}")
@@ -75,7 +45,7 @@ def _parse_s3_uri(uri):
     return parts[0], parts[1] if len(parts) > 1 else ""
 
 
-def _create_temp_file(content=None, suffix=".txt"):
+def _create_temp_file(content: str = None, suffix: str = ".txt") -> tuple:
     """Create a temporary file with random or specified content. Returns (path, content)."""
     if content is None:
         content = generate_uuid(40) + generate_uuid(40)
@@ -90,7 +60,7 @@ def _create_temp_file(content=None, suffix=".txt"):
 class PresignedEnvContext:
     """Context manager to set/unset the presigned upload environment variable."""
 
-    def __init__(self, enabled=True):
+    def __init__(self, enabled: bool = True):
         self._enabled = enabled
         self._original = None
 
@@ -120,7 +90,7 @@ class TestPresignedUrlUpload:
     def setup(self, tracking_server):
         mlflow.set_tracking_uri(tracking_server)
 
-        if not _presigned_upload_supported(tracking_server):
+        if not presigned_upload_supported(tracking_server):
             pytest.skip(
                 "Tracking server does not support presigned upload endpoint "
                 "(requires mlflow/mlflow#21039)"

--- a/test/integration/tests/test_presigned_url_upload.py
+++ b/test/integration/tests/test_presigned_url_upload.py
@@ -1,0 +1,236 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Integration tests for presigned URL artifact uploads.
+
+These tests require:
+  - A SageMaker MLflow tracking server (set MLFLOW_TRACKING_SERVER_URI or
+    MLFLOW_TRACKING_SERVER_NAME + REGION env vars)
+  - The server must have the presigned-upload-url endpoint (mlflow/mlflow#21039)
+  - AWS credentials with permission to call the tracking server and read S3
+
+Tests are skipped when the server does not support the presigned upload
+endpoint (HTTP 404), so they are safe to run against older servers.
+"""
+
+import logging
+import os
+import tempfile
+
+import mlflow
+import pytest
+
+from utils.boto_utils import get_file_data_from_s3
+from utils.random_utils import generate_uuid
+
+logger = logging.getLogger(__name__)
+
+_PRESIGNED_ENV_VAR = "SAGEMAKER_PRESIGNED_URL_UPLOAD"
+
+
+def _presigned_upload_supported(tracking_server_arn):
+    """Probe whether the tracking server supports the presigned upload endpoint."""
+    from mlflow.utils import rest_utils
+    from sagemaker_mlflow.mlflow_sagemaker_helpers import SageMakerMLflowHostMetadataProvider
+
+    provider = SageMakerMLflowHostMetadataProvider()
+    provider.set_arn(tracking_server_arn)
+    host_creds = rest_utils.MlflowHostCreds(
+        host=provider.construct_tracking_server_url(),
+        auth="arn",
+    )
+    try:
+        response = rest_utils.http_request(
+            host_creds,
+            "/api/2.0/mlflow/artifacts/presigned-upload-url",
+            "POST",
+            json={"run_id": "probe", "path": "probe.txt"},
+            raise_on_status=False,
+            max_retries=0,
+        )
+        # 404 = endpoint doesn't exist, 501 = not implemented
+        # Anything else (400, 403, etc.) means the endpoint exists
+        return response.status_code not in (404, 501)
+    except Exception as e:
+        logger.warning("Failed to probe presigned upload endpoint: %s", e)
+        return False
+
+
+def _parse_s3_uri(uri):
+    """Parse s3://bucket/key into (bucket, key)."""
+    if not uri.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URI: {uri}")
+    path = uri[len("s3://"):]
+    parts = path.split("/", 1)
+    return parts[0], parts[1] if len(parts) > 1 else ""
+
+
+def _create_temp_file(content=None, suffix=".txt"):
+    """Create a temporary file with random or specified content. Returns (path, content)."""
+    if content is None:
+        content = generate_uuid(40) + generate_uuid(40)
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=suffix, delete=False)
+    try:
+        f.write(content)
+    finally:
+        f.close()
+    return f.name, content
+
+
+class PresignedEnvContext:
+    """Context manager to set/unset the presigned upload environment variable."""
+
+    def __init__(self, enabled=True):
+        self._enabled = enabled
+        self._original = None
+
+    def __enter__(self):
+        self._original = os.environ.get(_PRESIGNED_ENV_VAR)
+        if self._enabled:
+            os.environ[_PRESIGNED_ENV_VAR] = "true"
+        else:
+            os.environ.pop(_PRESIGNED_ENV_VAR, None)
+        return self
+
+    def __exit__(self, *args):
+        if self._original is not None:
+            os.environ[_PRESIGNED_ENV_VAR] = self._original
+        else:
+            os.environ.pop(_PRESIGNED_ENV_VAR, None)
+
+
+class TestPresignedUrlUpload:
+    """Integration tests for presigned URL artifact uploads.
+
+    All tests in this class are skipped if the tracking server does not
+    support the presigned-upload-url endpoint (mlflow/mlflow#21039).
+    """
+
+    @pytest.fixture(scope="class")
+    def setup(self, tracking_server):
+        mlflow.set_tracking_uri(tracking_server)
+
+        if not _presigned_upload_supported(tracking_server):
+            pytest.skip(
+                "Tracking server does not support presigned upload endpoint "
+                "(requires mlflow/mlflow#21039)"
+            )
+
+    def test_presigned_upload_single_file(self, setup):
+        """Upload a single file via presigned URL and verify it in S3."""
+        file_path, file_contents = _create_temp_file()
+        file_name = os.path.basename(file_path)
+
+        try:
+            with PresignedEnvContext():
+                with mlflow.start_run() as run:
+                    mlflow.log_artifact(file_path)
+
+            artifact_uri = run.info.artifact_uri
+            bucket, prefix = _parse_s3_uri(artifact_uri)
+            key = f"{prefix}/{file_name}"
+
+            data = get_file_data_from_s3(bucket, key).read().decode("utf-8")
+            assert data == file_contents
+        finally:
+            os.remove(file_path)
+
+    def test_presigned_upload_with_artifact_path(self, setup):
+        """Upload a file to a subdirectory via presigned URL and verify in S3."""
+        file_path, file_contents = _create_temp_file()
+        file_name = os.path.basename(file_path)
+        artifact_subdir = "models/v1"
+
+        try:
+            with PresignedEnvContext():
+                with mlflow.start_run() as run:
+                    mlflow.log_artifact(file_path, artifact_subdir)
+
+            artifact_uri = run.info.artifact_uri
+            bucket, prefix = _parse_s3_uri(artifact_uri)
+            key = f"{prefix}/{artifact_subdir}/{file_name}"
+
+            data = get_file_data_from_s3(bucket, key).read().decode("utf-8")
+            assert data == file_contents
+        finally:
+            os.remove(file_path)
+
+    def test_presigned_upload_directory(self, setup):
+        """Upload a directory of files via presigned URL and verify all in S3."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            files = {}
+            for name in ["data.csv", "config.json", "readme.txt"]:
+                content = generate_uuid(30)
+                with open(os.path.join(tmp_dir, name), "w") as f:
+                    f.write(content)
+                files[name] = content
+
+            with PresignedEnvContext():
+                with mlflow.start_run() as run:
+                    mlflow.log_artifacts(tmp_dir, "output")
+
+            artifact_uri = run.info.artifact_uri
+            bucket, prefix = _parse_s3_uri(artifact_uri)
+
+            for name, expected_content in files.items():
+                key = f"{prefix}/output/{name}"
+                data = get_file_data_from_s3(bucket, key).read().decode("utf-8")
+                assert data == expected_content, f"Content mismatch for {name}"
+
+    def test_presigned_upload_can_be_downloaded(self, setup):
+        """File uploaded via presigned URL can be downloaded via mlflow client."""
+        file_path, file_contents = _create_temp_file()
+        file_name = os.path.basename(file_path)
+
+        try:
+            with PresignedEnvContext():
+                with mlflow.start_run() as run:
+                    mlflow.log_artifact(file_path)
+
+            client = mlflow.MlflowClient()
+            with tempfile.TemporaryDirectory() as download_dir:
+                download_path = client.download_artifacts(
+                    run.info.run_id, file_name, download_dir
+                )
+                with open(download_path, "r") as f:
+                    downloaded = f.read()
+                assert downloaded == file_contents
+        finally:
+            os.remove(file_path)
+
+
+class TestPresignedUrlUploadDisabled:
+    """Verify that artifact upload works normally when presigned is disabled."""
+
+    @pytest.fixture(scope="class")
+    def setup(self, tracking_server):
+        mlflow.set_tracking_uri(tracking_server)
+
+    def test_upload_without_presigned_env_var(self, setup):
+        """Without SAGEMAKER_PRESIGNED_URL_UPLOAD, uploads go through direct S3."""
+        file_path, file_contents = _create_temp_file()
+        file_name = os.path.basename(file_path)
+
+        try:
+            with PresignedEnvContext(enabled=False):
+                with mlflow.start_run() as run:
+                    mlflow.log_artifact(file_path)
+
+            artifact_uri = run.info.artifact_uri
+            bucket, prefix = _parse_s3_uri(artifact_uri)
+            key = f"{prefix}/{file_name}"
+
+            data = get_file_data_from_s3(bucket, key).read().decode("utf-8")
+            assert data == file_contents
+        finally:
+            os.remove(file_path)

--- a/test/integration/tests/test_presigned_url_upload.py
+++ b/test/integration/tests/test_presigned_url_upload.py
@@ -33,7 +33,7 @@ from utils.boto_utils import get_file_data_from_s3
 from utils.presigned_utils import presigned_upload_supported
 from utils.random_utils import generate_uuid
 
-_PRESIGNED_ENV_VAR = "SAGEMAKER_PRESIGNED_URL_UPLOAD"
+_PRESIGNED_ENV_VAR = "SAGEMAKER_PRESIGNED_URL_UPLOAD_ENABLED"
 
 
 def _parse_s3_uri(uri: str) -> tuple:
@@ -187,7 +187,7 @@ class TestPresignedUrlUploadDisabled:
         mlflow.set_tracking_uri(tracking_server)
 
     def test_upload_without_presigned_env_var(self, setup):
-        """Without SAGEMAKER_PRESIGNED_URL_UPLOAD, uploads go through direct S3."""
+        """Without SAGEMAKER_PRESIGNED_URL_UPLOAD_ENABLED, uploads go through direct S3."""
         file_path, file_contents = _create_temp_file()
         file_name = os.path.basename(file_path)
 

--- a/test/integration/utils/presigned_utils.py
+++ b/test/integration/utils/presigned_utils.py
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import logging
+
+from mlflow.utils import rest_utils
+from sagemaker_mlflow.mlflow_sagemaker_helpers import SageMakerMLflowHostMetadataProvider
+
+logger = logging.getLogger(__name__)
+
+_PRESIGNED_UPLOAD_ENDPOINT = "/api/2.0/mlflow/artifacts/presigned-upload-url"
+
+
+def presigned_upload_supported(tracking_server_arn: str) -> bool:
+    """Probe whether the tracking server supports the presigned upload endpoint."""
+    provider = SageMakerMLflowHostMetadataProvider()
+    provider.set_arn(tracking_server_arn)
+    host_creds = rest_utils.MlflowHostCreds(
+        host=provider.construct_tracking_server_url(),
+        auth="arn",
+    )
+    try:
+        response = rest_utils.http_request(
+            host_creds,
+            _PRESIGNED_UPLOAD_ENDPOINT,
+            "POST",
+            json={"run_id": "probe", "path": "probe.txt"},
+            raise_on_status=False,
+            max_retries=0,
+        )
+        # 404 = endpoint doesn't exist, 501 = not implemented
+        # Anything else (400, 403, etc.) means the endpoint exists
+        return response.status_code not in (404, 501)
+    except Exception as e:
+        logger.warning("Failed to probe presigned upload endpoint: %s", e)
+        return False

--- a/test/unit/test_s3_presigned_artifact_repo.py
+++ b/test/unit/test_s3_presigned_artifact_repo.py
@@ -244,39 +244,17 @@ class TestPresignedUploadHappyPath(TestCase):
         finally:
             os.unlink(tmp_path)
 
-    @mock.patch(f"{MODULE}.cloud_storage_http_request")
-    @mock.patch(f"{MODULE}.rest_utils.http_request")
-    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
-    def test_successful_upload_caches_supported(self, mock_provider_cls, mock_http, mock_cloud):
-        """#18: After successful presigned upload, _presigned_supported=True."""
-        mock_provider = mock_provider_cls.return_value
-        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
-        mock_http.return_value = _mock_response()
-        mock_cloud.return_value = _mock_response()
-
-        self.assertIsNone(self.repo._presigned_supported)
-
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
-            f.write(b"data")
-            tmp_path = f.name
-
-        try:
-            self.repo.log_artifact(tmp_path)
-            self.assertTrue(self.repo._presigned_supported)
-        finally:
-            os.unlink(tmp_path)
-
 
 class TestPermanentFailures(TestCase):
-    """Tests #5, #6, #9: permanent failure caching (404, 501)."""
+    """Tests #5, #6, #9: permanent failure behavior (404, 501)."""
 
     def setUp(self):
         self.repo = _create_repo()
 
     @mock.patch(f"{MODULE}.rest_utils.http_request")
     @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
-    def test_fallback_on_server_404(self, mock_provider_cls, mock_http):
-        """#5: Old server returns 404 → fallback + permanently cached."""
+    def test_server_404_raises(self, mock_provider_cls, mock_http):
+        """#5: Old server returns 404 → exception propagates."""
         mock_provider = mock_provider_cls.return_value
         mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
         mock_http.return_value = _mock_response(status_code=404)
@@ -286,20 +264,15 @@ class TestPermanentFailures(TestCase):
             tmp_path = f.name
 
         try:
-            with mock.patch.object(
-                S3PresignedArtifactRepository.__bases__[0], "log_artifact"
-            ) as mock_parent:
+            with self.assertRaises(Exception):
                 self.repo.log_artifact(tmp_path)
-                mock_parent.assert_called_once()
-
-            self.assertFalse(self.repo._presigned_supported)
         finally:
             os.unlink(tmp_path)
 
     @mock.patch(f"{MODULE}.rest_utils.http_request")
     @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
-    def test_fallback_on_server_501(self, mock_provider_cls, mock_http):
-        """#6: Non-S3 backend → fallback + permanently cached."""
+    def test_server_501_raises(self, mock_provider_cls, mock_http):
+        """#6: Non-S3 backend → exception propagates."""
         mock_provider = mock_provider_cls.return_value
         mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
         mock_http.return_value = _mock_response(status_code=501)
@@ -309,53 +282,22 @@ class TestPermanentFailures(TestCase):
             tmp_path = f.name
 
         try:
-            with mock.patch.object(
-                S3PresignedArtifactRepository.__bases__[0], "log_artifact"
-            ) as mock_parent:
+            with self.assertRaises(Exception):
                 self.repo.log_artifact(tmp_path)
-                mock_parent.assert_called_once()
-
-            self.assertFalse(self.repo._presigned_supported)
-        finally:
-            os.unlink(tmp_path)
-
-    @mock.patch(f"{MODULE}.rest_utils.http_request")
-    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
-    def test_permanent_cache_after_404(self, mock_provider_cls, mock_http):
-        """#9: After 404, all subsequent calls skip presigned without server contact."""
-        mock_provider = mock_provider_cls.return_value
-        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
-        mock_http.return_value = _mock_response(status_code=404)
-
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
-            f.write(b"data")
-            tmp_path = f.name
-
-        try:
-            with mock.patch.object(
-                S3PresignedArtifactRepository.__bases__[0], "log_artifact"
-            ) as mock_parent:
-                self.repo.log_artifact(tmp_path)
-                self.assertEqual(mock_http.call_count, 1)
-
-                mock_http.reset_mock()
-                self.repo.log_artifact(tmp_path)
-                mock_http.assert_not_called()
-                self.assertEqual(mock_parent.call_count, 2)
         finally:
             os.unlink(tmp_path)
 
 
 class TestTransientFailures(TestCase):
-    """Tests #7, #8, #10: transient failure handling (503, PUT failure)."""
+    """Tests #7, #8: transient failure handling (503, PUT failure)."""
 
     def setUp(self):
         self.repo = _create_repo()
 
     @mock.patch(f"{MODULE}.rest_utils.http_request")
     @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
-    def test_fallback_on_server_503_not_cached(self, mock_provider_cls, mock_http):
-        """#7: 503 → fallback but NOT cached (retries next call)."""
+    def test_server_503_raises(self, mock_provider_cls, mock_http):
+        """#7: 503 → exception propagates."""
         mock_provider = mock_provider_cls.return_value
         mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
         mock_http.return_value = _mock_response(status_code=503)
@@ -365,21 +307,16 @@ class TestTransientFailures(TestCase):
             tmp_path = f.name
 
         try:
-            with mock.patch.object(
-                S3PresignedArtifactRepository.__bases__[0], "log_artifact"
-            ) as mock_parent:
+            with self.assertRaises(Exception):
                 self.repo.log_artifact(tmp_path)
-                mock_parent.assert_called_once()
-
-            self.assertIsNone(self.repo._presigned_supported)
         finally:
             os.unlink(tmp_path)
 
     @mock.patch(f"{MODULE}.cloud_storage_http_request")
     @mock.patch(f"{MODULE}.rest_utils.http_request")
     @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
-    def test_fallback_on_put_failure_not_cached(self, mock_provider_cls, mock_http, mock_cloud):
-        """#8: PUT fails → fallback but NOT cached (retries next call)."""
+    def test_put_failure_raises(self, mock_provider_cls, mock_http, mock_cloud):
+        """#8: PUT fails → exception propagates."""
         mock_provider = mock_provider_cls.return_value
         mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
         mock_http.return_value = _mock_response()
@@ -390,43 +327,8 @@ class TestTransientFailures(TestCase):
             tmp_path = f.name
 
         try:
-            with mock.patch.object(
-                S3PresignedArtifactRepository.__bases__[0], "log_artifact"
-            ) as mock_parent:
+            with self.assertRaises(Exception):
                 self.repo.log_artifact(tmp_path)
-                mock_parent.assert_called_once()
-
-            self.assertIsNone(self.repo._presigned_supported)
-        finally:
-            os.unlink(tmp_path)
-
-    @mock.patch(f"{MODULE}.cloud_storage_http_request")
-    @mock.patch(f"{MODULE}.rest_utils.http_request")
-    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
-    def test_transient_failure_retries(self, mock_provider_cls, mock_http, mock_cloud):
-        """#10: After 503, next call attempts presigned again."""
-        mock_provider = mock_provider_cls.return_value
-        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
-
-        mock_http.return_value = _mock_response(status_code=503)
-
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
-            f.write(b"data")
-            tmp_path = f.name
-
-        try:
-            with mock.patch.object(
-                S3PresignedArtifactRepository.__bases__[0], "log_artifact"
-            ):
-                self.repo.log_artifact(tmp_path)
-                self.assertEqual(mock_http.call_count, 1)
-
-                mock_http.return_value = _mock_response()
-                mock_cloud.return_value = _mock_response()
-
-                self.repo.log_artifact(tmp_path)
-                self.assertEqual(mock_http.call_count, 2)
-                mock_cloud.assert_called_once()
         finally:
             os.unlink(tmp_path)
 
@@ -478,46 +380,21 @@ class TestDirectoryUploads(TestCase):
     @mock.patch(f"{MODULE}.cloud_storage_http_request")
     @mock.patch(f"{MODULE}.rest_utils.http_request")
     @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
-    def test_log_artifacts_partial_failure_per_file(
+    def test_log_artifacts_failure_propagates(
         self, mock_provider_cls, mock_http, mock_cloud
     ):
-        """#19: Directory with 3 files: one fails (503) → per-file fallback.
-
-        Exactly one file fails presigned (transient 503) and falls back to direct S3.
-        The other two files upload successfully via presigned URL.
-        """
+        """#19: If presigned upload fails for a file, exception propagates."""
         mock_provider = mock_provider_cls.return_value
         mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
-
-        call_count = {"n": 0}
-
-        def http_side_effect(*args, **kwargs):
-            call_count["n"] += 1
-            if call_count["n"] == 2:
-                return _mock_response(status_code=503)
-            return _mock_response()
-
-        mock_http.side_effect = http_side_effect
-        mock_cloud.return_value = _mock_response()
+        mock_http.return_value = _mock_response(status_code=503)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            for name in ["a.txt", "b.txt", "c.txt"]:
+            for name in ["a.txt", "b.txt"]:
                 with open(os.path.join(tmp_dir, name), "w") as f:
                     f.write("content")
 
-            with mock.patch.object(
-                S3PresignedArtifactRepository.__bases__[0], "log_artifact"
-            ) as mock_parent:
+            with self.assertRaises(Exception):
                 self.repo.log_artifacts(tmp_dir)
-
-                # Exactly one file should have fallen back to parent
-                self.assertEqual(mock_http.call_count, 3)
-                self.assertEqual(mock_cloud.call_count, 2)
-                self.assertEqual(mock_parent.call_count, 1)
-
-                # The file that fell back should be one of our test files
-                parent_call_file = os.path.basename(mock_parent.call_args[0][0])
-                self.assertIn(parent_call_file, ["a.txt", "b.txt", "c.txt"])
 
 
 if __name__ == "__main__":

--- a/test/unit/test_s3_presigned_artifact_repo.py
+++ b/test/unit/test_s3_presigned_artifact_repo.py
@@ -1,0 +1,490 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import os
+import tempfile
+import unittest
+from unittest import mock, TestCase
+
+from sagemaker_mlflow.s3_presigned_artifact_repo import (
+    SageMakerS3ArtifactRepository,
+    _SAGEMAKER_PRESIGNED_URL_UPLOAD_ENV_VAR,
+)
+
+TEST_VALID_ARN = "arn:aws:sagemaker:us-west-2:000000000000:mlflow-tracking-server/test-server"
+TEST_ARTIFACT_URI = "s3://test-bucket/123/abc456/artifacts"
+TEST_TRACKING_URL = "https://us-west-2.experiments.sagemaker.aws"
+TEST_PRESIGNED_URL = "https://test-bucket.s3.amazonaws.com/presigned-put?X-Amz-Signature=abc"
+
+MODULE = "sagemaker_mlflow.s3_presigned_artifact_repo"
+
+
+def _mock_response(status_code=200, json_data=None):
+    """Build a mock HTTP response."""
+    response = mock.Mock()
+    response.status_code = status_code
+    response.ok = status_code < 400
+    response.json.return_value = json_data or {
+        "presigned_url": TEST_PRESIGNED_URL,
+        "headers": {"Content-Type": "application/octet-stream"},
+    }
+    response.raise_for_status = mock.Mock()
+    if status_code >= 400:
+        from requests.exceptions import HTTPError
+
+        response.raise_for_status.side_effect = HTTPError(
+            f"HTTP {status_code}", response=response
+        )
+    return response
+
+
+def _create_repo(artifact_uri=TEST_ARTIFACT_URI, tracking_uri=TEST_VALID_ARN, env_enabled=True):
+    """Create a SageMakerS3ArtifactRepository with mocked parent init."""
+    env = {_SAGEMAKER_PRESIGNED_URL_UPLOAD_ENV_VAR: "true" if env_enabled else ""}
+    with mock.patch.dict(os.environ, env, clear=False):
+        with mock.patch(f"{MODULE}.S3ArtifactRepository.__init__", return_value=None):
+            repo = SageMakerS3ArtifactRepository(artifact_uri, tracking_uri=tracking_uri)
+            repo.artifact_uri = artifact_uri
+            repo.tracking_uri = tracking_uri
+            return repo
+
+
+class TestFeatureFlagAndInit(TestCase):
+    """Tests #1, #16, #17: feature flag, constructor, tracking_uri=None."""
+
+    def test_feature_disabled_uses_parent(self):
+        """#1: No env var → super().log_artifact() called, no server call."""
+        repo = _create_repo(env_enabled=False)
+
+        with mock.patch.object(
+            SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+        ) as mock_parent:
+            repo.log_artifact("/tmp/model.pkl")
+            mock_parent.assert_called_once_with("/tmp/model.pkl", None)
+
+    def test_constructor_receives_tracking_uri(self):
+        """#16: self.tracking_uri stored via parent ArtifactRepository.__init__."""
+        repo = _create_repo()
+        self.assertEqual(repo.tracking_uri, TEST_VALID_ARN)
+
+    def test_tracking_uri_none_skips_presigned(self):
+        """#17: tracking_uri=None → _should_use_presigned() returns False."""
+        repo = _create_repo(tracking_uri=None)
+        repo.tracking_uri = None
+        self.assertFalse(repo._should_use_presigned())
+
+        with mock.patch.object(
+            SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+        ) as mock_parent:
+            repo.log_artifact("/tmp/model.pkl")
+            mock_parent.assert_called_once()
+
+
+class TestRunIdExtraction(TestCase):
+    """Tests #11-14: run_id extraction from artifact URI."""
+
+    def test_run_id_extraction_standard(self):
+        """#11: s3://bucket/123/abc456/artifacts → 'abc456'."""
+        repo = _create_repo(artifact_uri="s3://bucket/123/abc456/artifacts")
+        self.assertEqual(repo._extract_run_id(), "abc456")
+
+    def test_run_id_extraction_with_subpath(self):
+        """#12: URI with subpath still extracts correctly."""
+        repo = _create_repo(artifact_uri="s3://bucket/123/abc456/artifacts/models/v1")
+        self.assertEqual(repo._extract_run_id(), "abc456")
+
+    def test_run_id_extraction_artifacts_in_prefix(self):
+        """#13: Reverse scan: s3://bucket/data/artifacts/123/abc456/artifacts → 'abc456'."""
+        repo = _create_repo(
+            artifact_uri="s3://bucket/data/artifacts/123/abc456/artifacts"
+        )
+        self.assertEqual(repo._extract_run_id(), "abc456")
+
+    def test_run_id_extraction_failure(self):
+        """#14: Malformed URI → returns None → falls back to direct S3."""
+        repo = _create_repo(artifact_uri="s3://bucket/no-artifacts-segment")
+        self.assertIsNone(repo._extract_run_id())
+        self.assertFalse(repo._should_use_presigned())
+
+
+class TestBuildUploadPath(TestCase):
+    """Tests #20, #21: _build_upload_path construction."""
+
+    def test_build_upload_path_no_artifact_path(self):
+        """#20: _build_upload_path('/tmp/model.pkl', None) → 'model.pkl'."""
+        repo = _create_repo()
+        self.assertEqual(repo._build_upload_path("/tmp/model.pkl", None), "model.pkl")
+
+    def test_build_upload_path_with_artifact_path(self):
+        """#21: _build_upload_path('/tmp/model.pkl', 'models/v1') → 'models/v1/model.pkl'."""
+        repo = _create_repo()
+        self.assertEqual(
+            repo._build_upload_path("/tmp/model.pkl", "models/v1"), "models/v1/model.pkl"
+        )
+
+
+class TestPresignedUploadHappyPath(TestCase):
+    """Tests #2, #3, #15, #18: successful presigned uploads."""
+
+    def setUp(self):
+        self.repo = _create_repo()
+
+    @mock.patch(f"{MODULE}.cloud_storage_http_request")
+    @mock.patch(f"{MODULE}.rest_utils.http_request")
+    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
+    def test_presigned_upload_happy_path(self, mock_provider_cls, mock_http, mock_cloud):
+        """#2: Mock server returns URL → file PUT uploaded via cloud_storage_http_request."""
+        mock_provider = mock_provider_cls.return_value
+        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
+        mock_http.return_value = _mock_response()
+        mock_cloud.return_value = _mock_response()
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
+            f.write(b"model_data")
+            tmp_path = f.name
+
+        try:
+            self.repo.log_artifact(tmp_path)
+
+            mock_http.assert_called_once()
+            call_kwargs = mock_http.call_args
+            self.assertEqual(call_kwargs[1]["json"]["run_id"], "abc456")
+
+            mock_cloud.assert_called_once()
+            cloud_call = mock_cloud.call_args
+            self.assertEqual(cloud_call[0][0], "put")
+            self.assertEqual(cloud_call[0][1], TEST_PRESIGNED_URL)
+        finally:
+            os.unlink(tmp_path)
+
+    @mock.patch(f"{MODULE}.cloud_storage_http_request")
+    @mock.patch(f"{MODULE}.rest_utils.http_request")
+    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
+    def test_presigned_upload_with_artifact_path(self, mock_provider_cls, mock_http, mock_cloud):
+        """#3: Server receives path='models/model.pkl' when artifact_path='models'."""
+        mock_provider = mock_provider_cls.return_value
+        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
+        mock_http.return_value = _mock_response()
+        mock_cloud.return_value = _mock_response()
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
+            f.write(b"model_data")
+            tmp_path = f.name
+
+        try:
+            self.repo.log_artifact(tmp_path, "models")
+
+            call_kwargs = mock_http.call_args
+            path_sent = call_kwargs[1]["json"]["path"]
+            expected = "models/" + os.path.basename(tmp_path)
+            self.assertEqual(path_sent, expected)
+        finally:
+            os.unlink(tmp_path)
+
+    @mock.patch(f"{MODULE}.cloud_storage_http_request")
+    @mock.patch(f"{MODULE}.rest_utils.http_request")
+    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
+    def test_presigned_upload_includes_headers(self, mock_provider_cls, mock_http, mock_cloud):
+        """#15: Server response headers forwarded in PUT request."""
+        mock_provider = mock_provider_cls.return_value
+        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
+
+        custom_headers = {
+            "Content-Type": "application/octet-stream",
+            "x-amz-server-side-encryption": "aws:kms",
+        }
+        mock_http.return_value = _mock_response(
+            json_data={"presigned_url": TEST_PRESIGNED_URL, "headers": custom_headers}
+        )
+        mock_cloud.return_value = _mock_response()
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
+            f.write(b"data")
+            tmp_path = f.name
+
+        try:
+            self.repo.log_artifact(tmp_path)
+
+            cloud_call = mock_cloud.call_args
+            self.assertEqual(cloud_call[1]["headers"], custom_headers)
+        finally:
+            os.unlink(tmp_path)
+
+    @mock.patch(f"{MODULE}.cloud_storage_http_request")
+    @mock.patch(f"{MODULE}.rest_utils.http_request")
+    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
+    def test_successful_upload_caches_supported(self, mock_provider_cls, mock_http, mock_cloud):
+        """#18: After successful presigned upload, _presigned_supported=True."""
+        mock_provider = mock_provider_cls.return_value
+        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
+        mock_http.return_value = _mock_response()
+        mock_cloud.return_value = _mock_response()
+
+        self.assertIsNone(self.repo._presigned_supported)
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
+            f.write(b"data")
+            tmp_path = f.name
+
+        try:
+            self.repo.log_artifact(tmp_path)
+            self.assertTrue(self.repo._presigned_supported)
+        finally:
+            os.unlink(tmp_path)
+
+
+class TestPermanentFailures(TestCase):
+    """Tests #5, #6, #9: permanent failure caching (404, 501)."""
+
+    def setUp(self):
+        self.repo = _create_repo()
+
+    @mock.patch(f"{MODULE}.rest_utils.http_request")
+    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
+    def test_fallback_on_server_404(self, mock_provider_cls, mock_http):
+        """#5: Old server returns 404 → fallback + permanently cached."""
+        mock_provider = mock_provider_cls.return_value
+        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
+        mock_http.return_value = _mock_response(status_code=404)
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
+            f.write(b"data")
+            tmp_path = f.name
+
+        try:
+            with mock.patch.object(
+                SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+            ) as mock_parent:
+                self.repo.log_artifact(tmp_path)
+                mock_parent.assert_called_once()
+
+            self.assertFalse(self.repo._presigned_supported)
+        finally:
+            os.unlink(tmp_path)
+
+    @mock.patch(f"{MODULE}.rest_utils.http_request")
+    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
+    def test_fallback_on_server_501(self, mock_provider_cls, mock_http):
+        """#6: Non-S3 backend → fallback + permanently cached."""
+        mock_provider = mock_provider_cls.return_value
+        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
+        mock_http.return_value = _mock_response(status_code=501)
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
+            f.write(b"data")
+            tmp_path = f.name
+
+        try:
+            with mock.patch.object(
+                SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+            ) as mock_parent:
+                self.repo.log_artifact(tmp_path)
+                mock_parent.assert_called_once()
+
+            self.assertFalse(self.repo._presigned_supported)
+        finally:
+            os.unlink(tmp_path)
+
+    @mock.patch(f"{MODULE}.rest_utils.http_request")
+    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
+    def test_permanent_cache_after_404(self, mock_provider_cls, mock_http):
+        """#9: After 404, all subsequent calls skip presigned without server contact."""
+        mock_provider = mock_provider_cls.return_value
+        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
+        mock_http.return_value = _mock_response(status_code=404)
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
+            f.write(b"data")
+            tmp_path = f.name
+
+        try:
+            with mock.patch.object(
+                SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+            ) as mock_parent:
+                self.repo.log_artifact(tmp_path)
+                self.assertEqual(mock_http.call_count, 1)
+
+                mock_http.reset_mock()
+                self.repo.log_artifact(tmp_path)
+                mock_http.assert_not_called()
+                self.assertEqual(mock_parent.call_count, 2)
+        finally:
+            os.unlink(tmp_path)
+
+
+class TestTransientFailures(TestCase):
+    """Tests #7, #8, #10: transient failure handling (503, PUT failure)."""
+
+    def setUp(self):
+        self.repo = _create_repo()
+
+    @mock.patch(f"{MODULE}.rest_utils.http_request")
+    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
+    def test_fallback_on_server_503_not_cached(self, mock_provider_cls, mock_http):
+        """#7: 503 → fallback but NOT cached (retries next call)."""
+        mock_provider = mock_provider_cls.return_value
+        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
+        mock_http.return_value = _mock_response(status_code=503)
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
+            f.write(b"data")
+            tmp_path = f.name
+
+        try:
+            with mock.patch.object(
+                SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+            ) as mock_parent:
+                self.repo.log_artifact(tmp_path)
+                mock_parent.assert_called_once()
+
+            self.assertIsNone(self.repo._presigned_supported)
+        finally:
+            os.unlink(tmp_path)
+
+    @mock.patch(f"{MODULE}.cloud_storage_http_request")
+    @mock.patch(f"{MODULE}.rest_utils.http_request")
+    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
+    def test_fallback_on_put_failure_not_cached(self, mock_provider_cls, mock_http, mock_cloud):
+        """#8: PUT fails → fallback but NOT cached (retries next call)."""
+        mock_provider = mock_provider_cls.return_value
+        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
+        mock_http.return_value = _mock_response()
+        mock_cloud.side_effect = Exception("Connection reset")
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
+            f.write(b"data")
+            tmp_path = f.name
+
+        try:
+            with mock.patch.object(
+                SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+            ) as mock_parent:
+                self.repo.log_artifact(tmp_path)
+                mock_parent.assert_called_once()
+
+            self.assertIsNone(self.repo._presigned_supported)
+        finally:
+            os.unlink(tmp_path)
+
+    @mock.patch(f"{MODULE}.cloud_storage_http_request")
+    @mock.patch(f"{MODULE}.rest_utils.http_request")
+    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
+    def test_transient_failure_retries(self, mock_provider_cls, mock_http, mock_cloud):
+        """#10: After 503, next call attempts presigned again."""
+        mock_provider = mock_provider_cls.return_value
+        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
+
+        mock_http.return_value = _mock_response(status_code=503)
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
+            f.write(b"data")
+            tmp_path = f.name
+
+        try:
+            with mock.patch.object(
+                SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+            ):
+                self.repo.log_artifact(tmp_path)
+                self.assertEqual(mock_http.call_count, 1)
+
+                mock_http.return_value = _mock_response()
+                mock_cloud.return_value = _mock_response()
+
+                self.repo.log_artifact(tmp_path)
+                self.assertEqual(mock_http.call_count, 2)
+                mock_cloud.assert_called_once()
+        finally:
+            os.unlink(tmp_path)
+
+
+class TestDirectoryUploads(TestCase):
+    """Tests #4, #19: log_artifacts directory handling."""
+
+    def setUp(self):
+        self.repo = _create_repo()
+
+    @mock.patch(f"{MODULE}.cloud_storage_http_request")
+    @mock.patch(f"{MODULE}.rest_utils.http_request")
+    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
+    def test_presigned_upload_directory(self, mock_provider_cls, mock_http, mock_cloud):
+        """#4: log_artifacts() calls self.log_artifact() per file, each via presigned URL."""
+        mock_provider = mock_provider_cls.return_value
+        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
+        mock_http.return_value = _mock_response()
+        mock_cloud.return_value = _mock_response()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            for name in ["file1.txt", "file2.txt", "file3.txt"]:
+                with open(os.path.join(tmp_dir, name), "w") as f:
+                    f.write("content")
+
+            self.repo.log_artifacts(tmp_dir, "output")
+
+        self.assertEqual(mock_http.call_count, 3)
+        self.assertEqual(mock_cloud.call_count, 3)
+
+        paths_sent = sorted(
+            call[1]["json"]["path"] for call in mock_http.call_args_list
+        )
+        self.assertEqual(
+            paths_sent,
+            ["output/file1.txt", "output/file2.txt", "output/file3.txt"],
+        )
+
+    @mock.patch(f"{MODULE}.cloud_storage_http_request")
+    @mock.patch(f"{MODULE}.rest_utils.http_request")
+    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
+    def test_log_artifacts_partial_failure_per_file(
+        self, mock_provider_cls, mock_http, mock_cloud
+    ):
+        """#19: Directory with 3 files: one fails (503) → per-file fallback.
+
+        Exactly one file fails presigned (transient 503) and falls back to direct S3.
+        The other two files upload successfully via presigned URL.
+        """
+        mock_provider = mock_provider_cls.return_value
+        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
+
+        call_count = {"n": 0}
+
+        def http_side_effect(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                return _mock_response(status_code=503)
+            return _mock_response()
+
+        mock_http.side_effect = http_side_effect
+        mock_cloud.return_value = _mock_response()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            for name in ["a.txt", "b.txt", "c.txt"]:
+                with open(os.path.join(tmp_dir, name), "w") as f:
+                    f.write("content")
+
+            with mock.patch.object(
+                SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+            ) as mock_parent:
+                self.repo.log_artifacts(tmp_dir)
+
+                # Exactly one file should have fallen back to parent
+                self.assertEqual(mock_http.call_count, 3)
+                self.assertEqual(mock_cloud.call_count, 2)
+                self.assertEqual(mock_parent.call_count, 1)
+
+                # The file that fell back should be one of our test files
+                parent_call_file = os.path.basename(mock_parent.call_args[0][0])
+                self.assertIn(parent_call_file, ["a.txt", "b.txt", "c.txt"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_s3_presigned_artifact_repo.py
+++ b/test/unit/test_s3_presigned_artifact_repo.py
@@ -17,7 +17,7 @@ import unittest
 from unittest import mock, TestCase
 
 from sagemaker_mlflow.s3_presigned_artifact_repo import (
-    SageMakerS3ArtifactRepository,
+    S3PresignedArtifactRepository,
     _SAGEMAKER_PRESIGNED_URL_UPLOAD_ENV_VAR,
 )
 
@@ -49,11 +49,11 @@ def _mock_response(status_code=200, json_data=None):
 
 
 def _create_repo(artifact_uri=TEST_ARTIFACT_URI, tracking_uri=TEST_VALID_ARN, env_enabled=True):
-    """Create a SageMakerS3ArtifactRepository with mocked parent init."""
+    """Create an S3PresignedArtifactRepository with mocked parent init."""
     env = {_SAGEMAKER_PRESIGNED_URL_UPLOAD_ENV_VAR: "true" if env_enabled else ""}
     with mock.patch.dict(os.environ, env, clear=False):
         with mock.patch(f"{MODULE}.S3ArtifactRepository.__init__", return_value=None):
-            repo = SageMakerS3ArtifactRepository(artifact_uri, tracking_uri=tracking_uri)
+            repo = S3PresignedArtifactRepository(artifact_uri, tracking_uri=tracking_uri)
             repo.artifact_uri = artifact_uri
             repo.tracking_uri = tracking_uri
             return repo
@@ -67,7 +67,7 @@ class TestFeatureFlagAndInit(TestCase):
         repo = _create_repo(env_enabled=False)
 
         with mock.patch.object(
-            SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+            S3PresignedArtifactRepository.__bases__[0], "log_artifact"
         ) as mock_parent:
             repo.log_artifact("/tmp/model.pkl")
             mock_parent.assert_called_once_with("/tmp/model.pkl", None)
@@ -84,7 +84,7 @@ class TestFeatureFlagAndInit(TestCase):
         self.assertFalse(repo._should_use_presigned())
 
         with mock.patch.object(
-            SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+            S3PresignedArtifactRepository.__bases__[0], "log_artifact"
         ) as mock_parent:
             repo.log_artifact("/tmp/model.pkl")
             mock_parent.assert_called_once()
@@ -164,6 +164,30 @@ class TestPresignedUploadHappyPath(TestCase):
             cloud_call = mock_cloud.call_args
             self.assertEqual(cloud_call[0][0], "put")
             self.assertEqual(cloud_call[0][1], TEST_PRESIGNED_URL)
+        finally:
+            os.unlink(tmp_path)
+
+    @mock.patch(f"{MODULE}.cloud_storage_http_request")
+    @mock.patch(f"{MODULE}.rest_utils.http_request")
+    @mock.patch(f"{MODULE}.SageMakerMLflowHostMetadataProvider")
+    def test_presigned_upload_streams_file(self, mock_provider_cls, mock_http, mock_cloud):
+        """Verify file is streamed (file handle passed) rather than read into memory."""
+        mock_provider = mock_provider_cls.return_value
+        mock_provider.construct_tracking_server_url.return_value = TEST_TRACKING_URL
+        mock_http.return_value = _mock_response()
+        mock_cloud.return_value = _mock_response()
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
+            f.write(b"model_data")
+            tmp_path = f.name
+
+        try:
+            self.repo.log_artifact(tmp_path)
+
+            cloud_call = mock_cloud.call_args
+            # data should be a file object, not bytes
+            data_arg = cloud_call[1]["data"]
+            self.assertTrue(hasattr(data_arg, "read"), "data should be a file-like object, not bytes")
         finally:
             os.unlink(tmp_path)
 
@@ -263,7 +287,7 @@ class TestPermanentFailures(TestCase):
 
         try:
             with mock.patch.object(
-                SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+                S3PresignedArtifactRepository.__bases__[0], "log_artifact"
             ) as mock_parent:
                 self.repo.log_artifact(tmp_path)
                 mock_parent.assert_called_once()
@@ -286,7 +310,7 @@ class TestPermanentFailures(TestCase):
 
         try:
             with mock.patch.object(
-                SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+                S3PresignedArtifactRepository.__bases__[0], "log_artifact"
             ) as mock_parent:
                 self.repo.log_artifact(tmp_path)
                 mock_parent.assert_called_once()
@@ -309,7 +333,7 @@ class TestPermanentFailures(TestCase):
 
         try:
             with mock.patch.object(
-                SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+                S3PresignedArtifactRepository.__bases__[0], "log_artifact"
             ) as mock_parent:
                 self.repo.log_artifact(tmp_path)
                 self.assertEqual(mock_http.call_count, 1)
@@ -342,7 +366,7 @@ class TestTransientFailures(TestCase):
 
         try:
             with mock.patch.object(
-                SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+                S3PresignedArtifactRepository.__bases__[0], "log_artifact"
             ) as mock_parent:
                 self.repo.log_artifact(tmp_path)
                 mock_parent.assert_called_once()
@@ -367,7 +391,7 @@ class TestTransientFailures(TestCase):
 
         try:
             with mock.patch.object(
-                SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+                S3PresignedArtifactRepository.__bases__[0], "log_artifact"
             ) as mock_parent:
                 self.repo.log_artifact(tmp_path)
                 mock_parent.assert_called_once()
@@ -392,7 +416,7 @@ class TestTransientFailures(TestCase):
 
         try:
             with mock.patch.object(
-                SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+                S3PresignedArtifactRepository.__bases__[0], "log_artifact"
             ):
                 self.repo.log_artifact(tmp_path)
                 self.assertEqual(mock_http.call_count, 1)
@@ -412,6 +436,16 @@ class TestDirectoryUploads(TestCase):
 
     def setUp(self):
         self.repo = _create_repo()
+
+    def test_log_artifacts_disabled_calls_parent(self):
+        """When presigned is disabled, log_artifacts delegates to parent directly."""
+        repo = _create_repo(env_enabled=False)
+
+        with mock.patch.object(
+            S3PresignedArtifactRepository.__bases__[0], "log_artifacts"
+        ) as mock_parent:
+            repo.log_artifacts("/tmp/some_dir", "output")
+            mock_parent.assert_called_once_with("/tmp/some_dir", "output")
 
     @mock.patch(f"{MODULE}.cloud_storage_http_request")
     @mock.patch(f"{MODULE}.rest_utils.http_request")
@@ -472,7 +506,7 @@ class TestDirectoryUploads(TestCase):
                     f.write("content")
 
             with mock.patch.object(
-                SageMakerS3ArtifactRepository.__bases__[0], "log_artifact"
+                S3PresignedArtifactRepository.__bases__[0], "log_artifact"
             ) as mock_parent:
                 self.repo.log_artifacts(tmp_dir)
 


### PR DESCRIPTION
# PR Description: Presigned URL Upload Support for S3 Artifacts

## Issue #, if available:

- mlflow/mlflow#21037 — Feature request: presigned upload URLs for `--no-serve-artifacts` deployments
- mlflow/mlflow#21039 — Server-side endpoint (OSS MLflow PR, dependency)

## Description of changes:

Adds `SageMakerS3ArtifactRepository`, a client-side plugin that uploads artifacts via presigned URLs obtained from the MLflow tracking server. This enables artifact uploads **without requiring direct S3 write credentials** on the client — the tracking server generates short-lived presigned URLs and the client PUTs directly to S3.

### Motivation

Today, SageMaker MLflow users in `--no-serve-artifacts` mode must have direct S3 write access to log artifacts. This PR adds an opt-in presigned upload path that lets the **tracking server broker S3 access**, matching the security model already used for presigned downloads ([mlflow/mlflow#20352](https://github.com/mlflow/mlflow/pull/20352)).

### How it works

```
Client                          Tracking Server              S3
  │                                   │                       │
  ├── POST /presigned-upload-url ────►│                       │
  │   (SigV4-authenticated)           ├── generate_presigned_url()
  │◄── { presigned_url, headers } ────┤                       │
  │                                   │                       │
  ├── PUT presigned_url ─────────────────────────────────────►│
  │   (no auth — embedded in URL)     │                       │
  │◄── 200 OK ───────────────────────────────────────────────┤
```

### Design decisions

| Decision | Rationale |
|---|---|
| **Opt-in via `SAGEMAKER_PRESIGNED_URL_UPLOAD=true`** | No behavior change for existing users; zero risk when env var is unset |
| **Subclass `S3ArtifactRepository`** | Inherits all existing S3 behavior; only `log_artifact`/`log_artifacts` are overridden |
| **Per-file fallback in `log_artifacts`** | If presigned fails for one file in a directory upload, only that file falls back to direct S3 — others continue via presigned |
| **Permanent cache for 404/501** | Server genuinely doesn't support the endpoint → stop trying |
| **No cache for 503/PUT errors** | Could be transient (network blip, S3 throttle) → retry on next call |
| **Reverse-scan `run_id` extraction** | Forward scan breaks when `"artifacts"` appears in the S3 prefix path (e.g., `s3://bucket/ml-artifacts/...`) |
| **Two HTTP paths** | Tracking server API uses `rest_utils.http_request` (SigV4). S3 PUT uses `cloud_storage_http_request` (no auth) — same pattern as `presigned_url_artifact_repo.py` in OSS MLflow |

### Safety analysis — global `s3://` scheme override

| Scenario | Behavior |
|---|---|
| SageMaker user, env var **not set** | Delegates to parent `S3ArtifactRepository` → identical to stock MLflow |
| SageMaker user, env var set, **new server** | Uses presigned URLs ✅ |
| SageMaker user, env var set, **old server** | First call gets 404 → caches fallback → direct S3 for all subsequent calls |
| Non-SageMaker user (plugin installed) | No env var → no change |
| `--serve-artifacts` mode | Uses `mlflow-artifacts://` scheme → this plugin not activated |

### Files changed

| File | Change |
|---|---|
| `sagemaker_mlflow/s3_presigned_artifact_repo.py` | **New** — `SageMakerS3ArtifactRepository` class |
| `setup.py` | **Modified** — register `mlflow.artifact_repository` entry point for `s3://` |
| `test/unit/test_s3_presigned_artifact_repo.py` | **New** — 21 unit tests covering happy path, failure caching, fallback, directory uploads, run_id extraction |
| `test/integration/tests/test_presigned_url_upload.py` | **New** — 5 integration tests (presigned upload, artifact path, directory, download roundtrip, disabled fallback) |

### Dependencies

> ⚠️ **This PR depends on [mlflow/mlflow#21039](https://github.com/mlflow/mlflow/pull/21039)** which adds the server-side `POST /api/2.0/mlflow/artifacts/presigned-upload-url` endpoint to OSS MLflow. This client-side PR is fully unit-tested against mocks. Integration tests include a runtime probe that gracefully skips when the endpoint is unavailable.

### Related PRs

- [mlflow/mlflow#20352](https://github.com/mlflow/mlflow/pull/20352) (merged) — Presigned **downloads** via artifact proxy pattern
- [mlflow/mlflow#21081](https://github.com/mlflow/mlflow/pull/21081) — Enforces presigned-only artifact transfers for `--serve-artifacts` mode
- mlflow/mlflow#21039 — Our server-side endpoint for `--no-serve-artifacts` mode

### Testing

- **21 unit tests** — all passing, covering:
  - Feature flag on/off, `tracking_uri=None` guard
  - `run_id` extraction (standard, subpath, artifacts-in-prefix, malformed)
  - `_build_upload_path` with/without artifact path
  - Happy path presigned upload, headers forwarding, cache-on-success
  - Permanent failure caching (404, 501) and subsequent skip
  - Transient failure retry (503, PUT failure)
  - Directory upload and partial-failure per-file fallback
- **5 integration tests** — require live SageMaker tracking server with presigned endpoint:
  - Single file upload + S3 verification
  - Upload with artifact subdirectory
  - Directory upload (multiple files)
  - Upload → download roundtrip
  - Disabled env var fallback to direct S3
- **80 total unit tests pass** (59 existing + 21 new), zero regressions

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
