### PR TITLE
Fix tox.ini: pin mlflow-skinny to match mlflow version in test envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,15 +50,25 @@ setenv =
     mlflow340: PYTEST_IGNORE_FLAGS=--ignore=test/unit/test_mlflow_sagemaker_workspace_store.py --ignore=test/integration/tests/test_workspace.py
 deps =
     setuptools<81 # https://github.com/ageitgey/face_recognition/issues/1645#issue-3128265021
+    mlflow28: mlflow>=2.8,<2.9
     mlflow28: mlflow-skinny>=2.8,<2.9
+    mlflow29: mlflow>=2.9,<2.10
     mlflow29: mlflow-skinny>=2.9,<2.10
+    mlflow210: mlflow>=2.10,<2.11
     mlflow210: mlflow-skinny>=2.10,<2.11
+    mlflow211: mlflow>=2.11,<2.12
     mlflow211: mlflow-skinny>=2.11,<2.12
+    mlflow212: mlflow>=2.12,<2.13
     mlflow212: mlflow-skinny>=2.12,<2.13
+    mlflow213: mlflow>=2.13,<2.14
     mlflow213: mlflow-skinny>=2.13,<2.14
+    mlflow216: mlflow>=2.16,<2.17
     mlflow216: mlflow-skinny>=2.16,<2.17
+    mlflow300: mlflow>=3.0.0,<3.1
     mlflow300: mlflow-skinny>=3.0.0,<3.1
+    mlflow340: mlflow>=3.4.0,<3.5
     mlflow340: mlflow-skinny>=3.4.0,<3.5
+    mlflow3100: mlflow>=3.10.0,<3.11
     mlflow3100: mlflow-skinny>=3.10.0,<3.11
     .[test]
 depends =


### PR DESCRIPTION
 *Issue #, if available:*
  
  #6
  
  *Description of changes:*
  
  Pin mlflow-skinny to match the full mlflow version in each tox test environment to prevent 
  version conflicts.
  
  When tox installs full mlflow (e.g. 2.13) for integration tests, the package's 
  mlflow-skinny>=2.8 dependency would cause pip to install the latest mlflow-skinny (3.12.0), 
  overwriting shared namespace files and causing import errors. Adding version-matched 
  mlflow-skinny pins ensures no mismatch.
  
  The package itself still ships with mlflow-skinny as the base dependency (changed in 0.4.0).
  Also removes unnecessary numpy/pyarrow/contourpy/datasets pins that are no longer needed.