### PR TITLE
feat: add Python 3.12, 3.13, and 3.14 to test matrix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,8 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
     # Depend on mlflow-skinny to avoid pulling in heavy data-science
     # dependencies (numpy, scipy, scikit-learn, pyarrow, etc.).

--- a/test/unit/test_mlflow_sagemaker_scorer_store.py
+++ b/test/unit/test_mlflow_sagemaker_scorer_store.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest import TestCase
+from unittest.mock import patch, MagicMock
 from sagemaker_mlflow.mlflow_sagemaker_scorer_store import MlflowSageMakerScorerStore
 
 TEST_VALID_ARN = "arn:aws:sagemaker:us-west-2:000000000000:mlflow-tracking-server/xw"
@@ -16,7 +17,8 @@ class MlflowSageMakerScorerStoreTest(TestCase):
         store = MlflowSageMakerScorerStore(TEST_VALID_APP_ARN)
         assert store is not None
 
-    def test_store_instantiation_none(self):
+    @patch("mlflow.genai.scorers.registry._get_store", return_value=MagicMock())
+    def test_store_instantiation_none(self, mock_get_store):
         store = MlflowSageMakerScorerStore()
         assert store is not None
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = black-format,flake8,twine,py39-mlflow{28,29,210,211,212,213,216,300},py{310,311}-mlflow{28,29,210,211,212,213,216,300,340,3100}
+envlist = black-format,flake8,twine,py39-mlflow{28,29,210,211,212,213,216,300},py{310,311,312}-mlflow{28,29,210,211,212,213,216,300,340,3100},py{313,314}-mlflow{300,340,3100}
 
 [flake8]
 max-line-length = 120
@@ -82,7 +82,8 @@ deps =
     .[test]
 depends =
     py39-mlflow{28,29,210,211,212,213,216,300}: clean
-    py{310,311}-mlflow{28,29,210,211,212,213,216,300,340,3100}: clean
+    py{310,311,312}-mlflow{28,29,210,211,212,213,216,300,340,3100}: clean
+    py{313,314}-mlflow{300,340,3100}: clean
 
 [testenv:runcoverage]
 description = run unit tests with coverage


### PR DESCRIPTION
## Summary

- Add Python 3.13 and 3.14 classifiers to `setup.py`
- Expand tox test matrix: py312 with all mlflow versions, py313/py314 with mlflow 3.0+ (older mlflow lacks support)
- Fix `test_store_instantiation_none` to mock `_get_store` since the test environment has no valid tracking URI configured

## Test plan

- [x] `tox -e flake8,black-check,typing,twine` — all pass
- [x] `tox -e runcoverage -- test/unit` — 100 unit tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.